### PR TITLE
All policies upload changes:

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "10.14.13",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.13.tgz",
-            "integrity": "sha512-yN/FNNW1UYsRR1wwAoyOwqvDuLDtVXnaJTZ898XIw/Q5cCaeVAlVwvsmXLX5PuiScBYwZsZU4JYSHB3TvfdwvQ==",
+            "version": "10.14.14",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.14.tgz",
+            "integrity": "sha512-xXD08vZsvpv4xptQXj1+ky22f7ZoKu5ZNI/4l+/BXG3X+XaeZsmaFbbTKuhSE3NjjvRuZFxFf9sQBMXIcZNFMQ==",
             "dev": true
         },
         "adal-node": {

--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
     },
     "devDependencies": {
         "@types/mocha": "^5.2.5",
-        "@types/node": "^10.14.13",
+        "@types/node": "^10.14.14",
         "typescript": "^3.2.2"
     },
     "dependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,10 @@
 import fs = require('fs');
 import * as vscode from 'vscode';
-import { WorkspaceConfiguration } from 'vscode';
 
 export default class Config {
 
-    private static config: WorkspaceConfiguration = vscode.workspace.getConfiguration();
-
     static GetDefaultEnvironment(): string {
-        return this.config.get("environment.default") as string;
+        return vscode.workspace.getConfiguration().get("environment.default") as string;
     }
 
     static GetEnvironments(): Promise<Array<any>> {

--- a/src/help/policy-upload.md
+++ b/src/help/policy-upload.md
@@ -44,8 +44,11 @@ To upload a policy
     ![Sign-in](media/policy-upload-singin2.png)
 - Sign-in with your Azure AD B2C tenant admin account
 
-## Uploaded all policies for an environment
-The default environment name in the extension's settings needs to be configured before using 'Upload all policies' command.
+## Upload all policies for an environment
+The default environment name in the extension's settings needs to be configured before using 'Upload all policies' command. if this is not set then the extension will upload policies from the root working folder. Before uploading a specific environment run **B2C Policy Build** command.
+
 The same process for logging in to Azure should be followed (refer to the "Upload a policy" section above).
-To initiate the upload press `ALT`+`SHIFT`+`U` or launch the **Upload all B2C Policies** command in the commands list (`CTRL`+`SHIFT`+`P`).
-Once all policies are successfully uploaded a popup will display a success message. An error message will be displayed for all failed uploads. 
+
+To initiate the upload press `ALT`+`SHIFT`+`U` or launch the **B2C Upload all policies** command in the commands list (`CTRL`+`SHIFT`+`P`).
+
+Once all policies are successfully uploaded a popup will display a success message stating the number of policies uploaded. An error message will be displayed for all failed uploads. If any of the policies have failed to upload the whole job will terminate immediately and an error message will be displayed.


### PR DESCRIPTION
- if no default environment set upload all policies will upload policies from the current folder 
- other xml files skipped
- more error handling added
- setting are read from the extension settings on every read
- node type definitions updated