### PR TITLE
fix: replaced assignment operator with comparison

### DIFF
--- a/src/PolicyUpload.ts
+++ b/src/PolicyUpload.ts
@@ -35,7 +35,7 @@ export default class PolicyUpload {
         return new Promise((resolve, reject) => context.acquireUserCode(resource, ClientId, 'es-mx', function (err, response) {
             if (err) {
                 console.log('well that didn\'t work: ' + err.message);
-                if (err.message = "Error login in - The clientId parameter is required.") {
+                if (err.message == "Error login in - The clientId parameter is required.") {
                     vscode.window.showErrorMessage("The Graph API ClientId has not been set in Settings.");
                 }
                 else {


### PR DESCRIPTION
Actual error message was hidden due to the wrongly used assignment operator instead of the comparison one.