### PR TITLE
Add a command to renumber journey steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
                 "title": "B2C Smart paste"
             },
             {
+                "command": "extension.policy.renumber",
+                "title": "B2C Renumber policy"
+            },
+            {
                 "command": "ApplicationInsightsExplorer.refresh",
                 "title": "Refresh",
                 "icon": {

--- a/package.json
+++ b/package.json
@@ -247,6 +247,11 @@
                     "default": "",
                     "description": "The B2C Upload ApplicationID"
                 },
+                "aadb2c.autoRenumber": {
+                    "type": "boolean",
+                    "defaul": true,
+                    "description": "Automatically renumber out of order orchestration steps when building"
+                },
                 "environment.default": {
                     "type": "string",
                     "default": "",

--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
                 },
                 "aadb2c.autoRenumber": {
                     "type": "boolean",
-                    "defaul": true,
+                    "default": true,
                     "description": "Automatically renumber out of order orchestration steps when building"
                 },
                 "environment.default": {

--- a/src/PolicyBuild.ts
+++ b/src/PolicyBuild.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import fs = require('fs');
 import path = require('path');
 import Consts from './Consts';
+import PolicyCommands from './PolicyCommands';
 
 export default class PolicBuild {
     static Build() {
@@ -63,6 +64,11 @@ export default class PolicBuild {
 
                             return policyFiles;
                         }).then((policyFiles) => {
+                            // Automatically renumber orchestration steps if they are out of order
+                            let config = vscode.workspace.getConfiguration('aadb2c');
+                            if (config.autoRenumber) {
+                                PolicyCommands.renumberPolicies(policyFiles);
+                            }
 
                             // Get the app settings
                             vscode.workspace.openTextDocument(filePath).then(doc => {

--- a/src/PolicyCommands.ts
+++ b/src/PolicyCommands.ts
@@ -1,10 +1,123 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { DOMParser, Document } from 'xmldom';
+import { PolicyFile } from './PolicyBuild';
 
-const xpath = require('xpath');
-const selector = xpath.useNamespaces({ "ns": "http://schemas.microsoft.com/online/cpim/schemas/2013/06" });
+const _selector = require('xpath').useNamespaces({ "ns": "http://schemas.microsoft.com/online/cpim/schemas/2013/06" });
+
+class Policy {
+    xml: Document;
+    file: PolicyFile;
+    base: Policy | undefined;
+    processed: boolean;
+    splitFile: string[];
+    policyId: string;
+    journeys: Set<string>;
+    renumbered: number;
+    constructor(file) {
+        this.file = file;
+        this.xml = new DOMParser().parseFromString(file.Data, "application/xml");
+        this.policyId = this.selector("string(/ns:TrustFrameworkPolicy/@PolicyId)");
+        this.processed = false;
+        this.splitFile = file.Data.split("\n");
+        this.journeys = new Set();
+        this.renumbered = 0;
+    }
+
+    selector(s: string): any {
+        return _selector(s, this.xml);
+    }
+
+    process() {
+        if (this.processed) {
+            return;
+        }
+        if (this.base && !this.base.processed) {
+            this.base.process();
+            this.base.journeys.forEach(j => this.journeys.add(j));
+        }
+        this.processed = true;
+        let journeys = this.selector("/ns:TrustFrameworkPolicy/ns:UserJourneys/ns:UserJourney");
+        if (journeys.length === 0) {
+            return;
+        }
+        for (let journey of journeys) {
+            let journeyId = _selector("string(./@Id)", journey);
+            this.journeys.add(journeyId);
+            if (this.base && this.base.journeys.has(journeyId)) {
+                vscode.window.showInformationMessage(`Skipped renumbering ${this.policyId} because it has a base journey in another file`);
+                continue; // We won't renumber anything which has the journey defined in its base because
+                          // it's impossible to know what the programmer intends
+            }
+            let steps = _selector("./ns:OrchestrationSteps/ns:OrchestrationStep", journey);
+            for (let stepIndex = 0; stepIndex < steps.length; stepIndex++) {
+                let orderAttrs = _selector("./@Order", steps[stepIndex]);
+                if (orderAttrs.length === 0) {
+                    vscode.window.showErrorMessage(`Step ${stepIndex} of ${this.policyId} is missing the 'Order' attribute`);
+                    continue;
+                }
+                let orderAttr = orderAttrs[0];
+                if (orderAttr.value !== (stepIndex+1).toString()) {
+                    orderAttr.value = (stepIndex+1).toString();
+                    this.setOrder(orderAttr);
+                    this.renumbered++;
+                }
+            }
+        }
+        if (this.renumbered > 0) {
+            this.save();
+            vscode.window.showInformationMessage(`Renumbered ${this.renumbered} steps in ${this.policyId}`);
+        }
+    }
+
+    setOrder(orderAttr) {
+        let line = this.splitFile[orderAttr.lineNumber - 1];
+        line = line.substring(0, orderAttr.columnNumber) + orderAttr.value + line.substring(orderAttr.columnNumber + orderAttr.nodeValue.length);
+        this.splitFile[orderAttr.lineNumber - 1] = line;
+    }
+
+    save() {
+        this.file.Data = "";
+        for (let s of this.splitFile) {
+            this.file.Data += s + "\n";
+        }
+        this.file.Data = this.file.Data.trimRight();
+        if (this.file.SubFolder) {
+            fs.writeFile(path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, this.file.SubFolder, this.file.FileName),
+                         this.file.Data, e => vscode.window.showErrorMessage(e.message));
+        } else {
+            fs.writeFile(path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, this.file.FileName),
+                         this.file.Data, e => vscode.window.showErrorMessage(e.message));
+        }
+    }
+}
 
 export default class PolicyCommands {
-    static renumberPolicy(): any {
+    static renumberPolicies(files): any {
+        let policies: Map<string, Policy> = new Map();
+        for (let file of files) {
+            let policy = new Policy(file);
+            if (!policy.policyId) {
+                continue;
+            }
+            policies.set(policy.policyId, policy);
+        }
+
+        // Iterate over all the policies to determine if they have a base file
+        for (let policy of policies.values()) {
+            let base = policy.selector("string(/ns:TrustFrameworkPolicy/ns:BasePolicy/ns:PolicyId)");
+            if (base && policies.has(base)) {
+                policy.base = policies.get(base);
+            }
+        }
+
+        for (let policy of policies.values()) {
+            policy.process();
+        }
+    }
+
+    static renumberPolicyCommand(): any {
         try {
             var editor: vscode.TextEditor = vscode.window.activeTextEditor as vscode.TextEditor;
 
@@ -13,16 +126,15 @@ export default class PolicyCommands {
                 return;
             }
 
-            var DOMParser = require('xmldom').DOMParser;
             var xmlDoc = new DOMParser().parseFromString(editor.document.getText(), "application/xml");
 
-            let journeys = selector("/ns:TrustFrameworkPolicy/ns:UserJourneys/ns:UserJourney", xmlDoc);
+            let journeys = _selector("/ns:TrustFrameworkPolicy/ns:UserJourneys/ns:UserJourney", xmlDoc);
             if (journeys.length === 0) {
                 vscode.window.showInformationMessage("No journeys to renumber");
             }
 
             for (let journey of journeys) {
-                let steps = selector("./ns:OrchestrationSteps/ns:OrchestrationStep", journey);
+                let steps = _selector("./ns:OrchestrationSteps/ns:OrchestrationStep", journey);
                 if (steps.length === 0) {
                     vscode.window.showInformationMessage("No steps to renumber");
                     continue;
@@ -53,7 +165,6 @@ export default class PolicyCommands {
             vscode.window.showInformationMessage("Steps renumbered successfully");
         } catch (e) {
             vscode.window.showErrorMessage(e.message);
-            console.log(e.message);
         }
     }
 

--- a/src/PolicyCommands.ts
+++ b/src/PolicyCommands.ts
@@ -25,7 +25,7 @@ export default class PolicyCommands {
                 let steps = selector("./ns:OrchestrationSteps/ns:OrchestrationStep", journey);
                 if (steps.length === 0) {
                     vscode.window.showInformationMessage("No steps to renumber");
-                    return;
+                    continue;
                 }
                 editor.edit((editBuilder) => {
                     for (let i = 0; i < steps.length; i++) {
@@ -33,6 +33,7 @@ export default class PolicyCommands {
                         for (let j = 0; j < steps[i].attributes.length; j++) {
                             if (steps[i].attributes[j].name === "Order") {
                                 orderAttr = steps[i].attributes[j];
+                                break;
                             }
                         }
                         if (!orderAttr) {

--- a/src/PolicyCommands.ts
+++ b/src/PolicyCommands.ts
@@ -1,0 +1,59 @@
+import * as vscode from 'vscode';
+
+const xpath = require('xpath');
+const selector = xpath.useNamespaces({ "ns": "http://schemas.microsoft.com/online/cpim/schemas/2013/06" });
+
+export default class PolicyCommands {
+    static renumberPolicy(): any {
+        try {
+            var editor: vscode.TextEditor = vscode.window.activeTextEditor as vscode.TextEditor;
+
+            if (!editor) {
+                vscode.window.showErrorMessage("No document is open");
+                return;
+            }
+
+            var DOMParser = require('xmldom').DOMParser;
+            var xmlDoc = new DOMParser().parseFromString(editor.document.getText(), "application/xml");
+
+            let journeys = selector("/ns:TrustFrameworkPolicy/ns:UserJourneys/ns:UserJourney", xmlDoc);
+            if (journeys.length === 0) {
+                vscode.window.showInformationMessage("No journeys to renumber");
+            }
+
+            for (let journey of journeys) {
+                let steps = selector("./ns:OrchestrationSteps/ns:OrchestrationStep", journey);
+                if (steps.length === 0) {
+                    vscode.window.showInformationMessage("No steps to renumber");
+                    return;
+                }
+                editor.edit((editBuilder) => {
+                    for (let i = 0; i < steps.length; i++) {
+                        let orderAttr;
+                        for (let j = 0; j < steps[i].attributes.length; j++) {
+                            if (steps[i].attributes[j].name === "Order") {
+                                orderAttr = steps[i].attributes[j];
+                            }
+                        }
+                        if (!orderAttr) {
+                            vscode.window.showWarningMessage(`Step ${i} missing order attribute. Will not be renumbered!`);
+                            continue;
+                        }
+
+                        let start = new vscode.Position(orderAttr.lineNumber - 1, orderAttr.columnNumber);
+                        let end = new vscode.Position(orderAttr.lineNumber - 1, orderAttr.columnNumber + orderAttr.nodeValue.length);
+
+                        let range = new vscode.Range(start, end);
+
+                        editBuilder.replace(range, (i + 1).toString());
+                    }
+                });
+            }
+            vscode.window.showInformationMessage("Steps renumbered successfully");
+        } catch (e) {
+            vscode.window.showErrorMessage(e.message);
+            console.log(e.message);
+        }
+    }
+
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,7 +102,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('extension.policy.upload', () => PolicyUpload.uploadCurrentPolicy()));
 
     // Upload currently open Policy
-    context.subscriptions.push(vscode.commands.registerCommand('extension.policy.renumber', () => PolicyCommands.renumberPolicy()));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.policy.renumber', () => PolicyCommands.renumberPolicyCommand()));
 
     // Upload all policies for the default environment
     context.subscriptions.push(vscode.commands.registerCommand('extension.policy.uploadAll', () => PolicyUpload.uploadAllPolicies()));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import CompletionProvider from './CompletionProvider';
 import XsdHelper from './services/XsdHelper';
 import PolicyUpload from './PolicyUpload';
 import B2CArtifacts from './B2CArtifacts';
+import PolicyCommands from './PolicyCommands';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -100,11 +101,14 @@ export function activate(context: vscode.ExtensionContext) {
     // Upload currently open Policy
     context.subscriptions.push(vscode.commands.registerCommand('extension.policy.upload', () => PolicyUpload.uploadCurrentPolicy()));
 
+    // Upload currently open Policy
+    context.subscriptions.push(vscode.commands.registerCommand('extension.policy.renumber', () => PolicyCommands.renumberPolicy()));
+
     // Upload all policies for the default environment
     context.subscriptions.push(vscode.commands.registerCommand('extension.policy.uploadAll', () => PolicyUpload.uploadAllPolicies()));
 
     // Update appSettings with IEF appIds and B2C extension app id and object id
-    context.subscriptions.push(vscode.commands.registerCommand('extension.settings.b2cArtifacts', () => B2CArtifacts.GetB2CArtifacts()));    
+    context.subscriptions.push(vscode.commands.registerCommand('extension.settings.b2cArtifacts', () => B2CArtifacts.GetB2CArtifacts()));
 
     // Load IEF schema
     XsdHelper.getIefSchema();


### PR DESCRIPTION
Pretty much does what the title says. Simply adds a command that will renumber the orchestration steps of user journeys. Makes life way easier when you have to insert a new step at the beginning of your policy.