### PR TITLE
Yoelhor

### DIFF
--- a/src/ApplicationInsightsExplorerExplorerProvider.ts
+++ b/src/ApplicationInsightsExplorerExplorerProvider.ts
@@ -622,7 +622,7 @@ export default class ApplicationInsightsExplorerExplorerProvider implements vsco
 			` + claimsTransformation + `
 		
 		<h2>Application Insights JSON</h2>
-		<input type="button" onclick="copyJson()" id="copyJson" value="copy log to clipboard" />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<input type="button" onclick="copyJson()" id="copyJson" value="Copy log to clipboard" />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 		<input type="text" id="searchbox" />
 		<input type="button" onclick="highlight()" value="Search" />
 		<pre><code id='json'>` + appInsightsItem.Data + `</code></pre>

--- a/src/ApplicationInsightsExplorerExplorerProvider.ts
+++ b/src/ApplicationInsightsExplorerExplorerProvider.ts
@@ -513,6 +513,8 @@ export default class ApplicationInsightsExplorerExplorerProvider implements vsco
 					}
 				}
 			}
+
+
 			for (var key of Object.keys(claims)) {
 				claimsString += "<li>" + key + ": ";
 				for (var i in claims[key]) {
@@ -524,6 +526,7 @@ export default class ApplicationInsightsExplorerExplorerProvider implements vsco
 			}
 
 			if (claimsString.length > 1) {
+				claimsString = claimsString.split("<li>").sort().join("<li>")
 				claimsString = "<h2>Claims</h2><ul>" + claimsString + "</ul>";
 			}
 

--- a/src/ApplicationInsightsExplorerExplorerProvider.ts
+++ b/src/ApplicationInsightsExplorerExplorerProvider.ts
@@ -168,7 +168,7 @@ export default class ApplicationInsightsExplorerExplorerProvider implements vsco
 						info.value[i].customDimensions.CorrelationId,
 						info.value[i].timestamp,
 						element.trace.message,
-						(element.trace.message.indexOf('Exception') > 0)
+						(element.trace.message.indexOf('"Exception"') > 0) 
 					));
 				}
 
@@ -194,6 +194,10 @@ export default class ApplicationInsightsExplorerExplorerProvider implements vsco
 								this.AppInsightsItems[i].OrchestrationStep += ", " + element
 							}
 						});
+
+						if (this.AppInsightsItems[i].OrchestrationStep.length > 0 &&
+							(!this.AppInsightsItems[i].OrchestrationStep.startsWith("Step")))
+							this.AppInsightsItems[i].OrchestrationStep = "Step " + this.AppInsightsItems[i].OrchestrationStep;
 
 						// Remove the second entity 
 						this.AppInsightsItems.splice(i + 1, 1);

--- a/src/ApplicationInsightsExplorerExplorerProvider.ts
+++ b/src/ApplicationInsightsExplorerExplorerProvider.ts
@@ -411,18 +411,21 @@ export default class ApplicationInsightsExplorerExplorerProvider implements vsco
 					var obj = collection[i].Value.Values[x];
 
 					if (obj["Key"] === "Id") {
+
+						if (claimsTransformation.length > 0) claimsTransformation += "<br />";
+
 						// Get the claims transformation name 
-						claimsTransformation = "<div>" + obj["Value"] + "</div><table><tr><th>Item</th><th>Name</th><th>Value</th></tr>";
+						claimsTransformation += "<div>" + obj["Value"] + "</div><table><tr><th>Item</th><th>Name</th><th>Value</th></tr>";
 					}
 					else {
 						var name = "";
 
-						if (obj["Key"] === "InputClaim" || obj["Key"] === "Result") 
+						if (obj["Key"] === "InputClaim" || obj["Key"] === "Result")
 							name = obj.Value["PolicyClaimType"];
 						else
 							name = obj.Value.Id;
 
-						claimsTransformation += "<tr><td>" + obj["Key"].toString().replace("Result","OutputClaim") + "</td><td>" + name + "</td><td>" + obj.Value.Value + "</td></tr>";
+						claimsTransformation += "<tr><td>" + obj["Key"].toString().replace("Result", "OutputClaim") + "</td><td>" + name + "</td><td>" + obj.Value.Value + "</td></tr>";
 					}
 				}
 
@@ -430,7 +433,7 @@ export default class ApplicationInsightsExplorerExplorerProvider implements vsco
 			}
 
 			if (claimsTransformation.length > 1) {
-				claimsTransformation = "<h2>Claims transformation</h2>" + claimsTransformation ;
+				claimsTransformation = "<h2>Claims transformation</h2>" + claimsTransformation;
 			}
 
 			// Get the fatal exceptions

--- a/src/ApplicationInsightsExplorerExplorerProvider.ts
+++ b/src/ApplicationInsightsExplorerExplorerProvider.ts
@@ -571,7 +571,7 @@ export default class ApplicationInsightsExplorerExplorerProvider implements vsco
 	<body>
 		  <h1>Application Insights</h1>
 		<ul>
-  			<li>User Journey: ` + appInsightsItem.UserJourney + `</li>
+  			<li>Policy: ` + appInsightsItem.UserJourney + `</li>
   			<li>Correlation Id: ` + appInsightsItem.CorrelationId + `</li>
 			<li>App insights Id: ` + appInsightsItem.Id + `</li>
 			<li>App insights timestamp: ` + this.formatDate(new Date(appInsightsItem.Timestamp.toString())) + `</li>

--- a/src/ApplicationInsightsExplorerExplorerProvider.ts
+++ b/src/ApplicationInsightsExplorerExplorerProvider.ts
@@ -168,7 +168,7 @@ export default class ApplicationInsightsExplorerExplorerProvider implements vsco
 						info.value[i].customDimensions.CorrelationId,
 						info.value[i].timestamp,
 						element.trace.message,
-						(element.trace.message.indexOf('"Exception"') > 0) 
+						(element.trace.message.indexOf('"Exception"') > 0)
 					));
 				}
 
@@ -404,6 +404,7 @@ export default class ApplicationInsightsExplorerExplorerProvider implements vsco
 		var claimsString = '';
 		var journeyIsCompleted = 'No';
 		var internalError = '';
+		var tokens = ''
 
 		try {
 			json = JSON.parse(data);
@@ -491,6 +492,23 @@ export default class ApplicationInsightsExplorerExplorerProvider implements vsco
 			if (exceptions.length > 1) {
 				exceptions = "<h2 style='color: red;'>Exceptions</h2><ol>" + exceptions + "</ol>";
 			}
+
+			// Tokens
+			collection = jp.query(json, '$..[?(@.ContentType)]');
+			for (var i in collection) {
+
+				var array = collection[i].Value.split(";")
+
+				if (array.length > 1)
+					tokens += '<li>' + array[2] + " (" + collection[i].ContentType + "): " + array[0] + '</li>';
+				else
+					tokens += '<li>' + collection[i].Value + '</li>';
+			}
+
+			if (tokens.length > 1) {
+				tokens = "<h2>Tokens</h2><ol>" + tokens + "</ol>";
+			}
+
 			// Get the claims
 			var normalizedJson = JSON.parse(appInsightsItem.Data.toString().replace(new RegExp('Complex\-CLMS', "g"), "ComplexCLMS"))
 			collection = jp.query(normalizedJson, '$..ComplexCLMS');
@@ -624,7 +642,7 @@ export default class ApplicationInsightsExplorerExplorerProvider implements vsco
 			` + validationTechnicalProfiles + `
 			` + claimsString + `
 			` + claimsTransformation + `
-		
+			` + tokens + `
 		<h2>Application Insights JSON</h2>
 		<input type="button" onclick="copyJson()" id="copyJson" value="Copy log to clipboard" />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 		<input type="text" id="searchbox" />


### PR DESCRIPTION
Fix to show Application Insights report with multiple claims transformation
Fix to a case where the Application Insight breaks the entity into two lines 
Sort the AI report claims collection
Fix to the AI tree Exception icon
AI report tokens presentation