### PR TITLE
Fix silent build failure if user has invalid XML files

### DIFF
--- a/src/OrchestrationStepsRenumber.ts
+++ b/src/OrchestrationStepsRenumber.ts
@@ -39,6 +39,7 @@ export default class OrchestrationStepsRenumber {
                 policy = new Policy(file);
             } catch (e) {
                 vscode.window.showErrorMessage(`${file.FileName} has invalid XML. Skipping renumber for this file`);
+                continue;
             }
             if (!policy.policyId) {
                 continue;

--- a/src/OrchestrationStepsRenumber.ts
+++ b/src/OrchestrationStepsRenumber.ts
@@ -34,7 +34,12 @@ export default class OrchestrationStepsRenumber {
     static RenumberPolicies(files): any {
         let policies: Map<string, Policy> = new Map();
         for (let file of files) {
-            let policy = new Policy(file);
+            let policy = null;
+            try {
+                policy = new Policy(file);
+            } catch (e) {
+                vscode.window.showErrorMessage(`${file.FileName} has invalid XML. Skipping renumber for this file`);
+            }
             if (!policy.policyId) {
                 continue;
             }


### PR DESCRIPTION
Fixes an issue where the extension will simply fail silently to build if there's an invalid XML file in your project.

Steps to recreate:
1. Create a blank XML file in your project
2. Build
3. It will appear to do nothing while throwing an error in the debug console

This fix simply catches the error and lets the user know which XML file couldn't be renumbered due to the issue.

![image](https://user-images.githubusercontent.com/2773983/112916744-2945c380-90cf-11eb-99c1-00c6958bc699.png)
