### PR TITLE
Fix: build ps script now uses 'EnvironmentsFolder' setting

### DIFF
--- a/scripts/Build-CustomPolicies.ps1
+++ b/scripts/Build-CustomPolicies.ps1
@@ -33,7 +33,7 @@ try{
     Write-Verbose "Files found: $XmlPolicyFiles"
 
     #Get the app settings                        
-    $EnvironmentsRootPath = Join-Path $FilePath "Environments"
+    $EnvironmentsRootPath = Join-Path $FilePath ($AppSettingsJson.EnvironmentsFolder ?? "Environments")
 
     #Ensure environments folder exists
     if((Test-Path -Path $EnvironmentsRootPath -PathType Container) -ne $true)


### PR DESCRIPTION
Currently, the build ps script ignores the 'EnvironmentsFolder' setting. This PR fixes that. Defaults to "Environments" if the setting is not present.