### PR TITLE
Add recursive base check for policy renumbering (Fixes #68)

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,6 +253,11 @@
                     "default": "",
                     "description": "The B2C Upload ApplicationID"
                 },
+                "aadb2c.maxPolicyRenumberDepth": {
+                    "type": "integer",
+                    "default": 15,
+                    "description": "When analyzing base files while auto-renumbering, the maximum depth to examine before stopping. Shouldn't need to change this value unless you have a ridiculous number of base policies."
+                },
                 "aadb2c.autoRenumber": {
                     "type": "boolean",
                     "default": true,

--- a/src/OrchestrationStepsRenumber.ts
+++ b/src/OrchestrationStepsRenumber.ts
@@ -25,7 +25,8 @@ export default class OrchestrationStepsRenumber {
                 OrchestrationStepsRenumber.renumberOrchestrationSteps(xmlDoc, editBuilder, "/ns:TrustFrameworkPolicy/ns:SubJourneys/ns:SubJourney");
             });
 
-        } catch (e: any) {
+        } catch (e) {
+            // @ts-ignore - This message should always exist
             vscode.window.showErrorMessage(e.message);
         }
     }


### PR DESCRIPTION
This change adds some minor changes to the orchestration renumbering used for the build system to enable a recursive check of all the bases of each policy.

There are also some safety checks to ensure that it cannot hit an infinite loop, and that the depth check has a reasonable limit (which I can't imagine anybody ever really exceeding).

This fixes issue #68.