### PR TITLE
Add build single policy command and provide build status in a notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,11 @@
             },
             {
                 "command": "extension.policy.build",
-                "title": "B2C Policy build"
+                "title": "B2C Build all policies"
+            },
+            {
+                "command": "extension.policy.buildSingle",
+                "title": "B2C Build current policy"
             },
             {
                 "command": "extension.policy.smartCopy",
@@ -122,6 +126,12 @@
                 "command": "extension.policy.build",
                 "key": "shift+ctrl+5",
                 "mac": "shift+cmd+5",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "extension.policy.buildSingle",
+                "key": "shift+ctrl+6",
+                "mac": "shift+cmd+6",
                 "when": "editorTextFocus"
             },
             {

--- a/src/PolicyBuild.ts
+++ b/src/PolicyBuild.ts
@@ -8,6 +8,7 @@ export default class PolicBuild {
     static Build({singlePolicy = false} = {}) {
 
         var policyFilter: string = "**/*.{xml}";
+        var targetPolicy: string = "";
         if (singlePolicy) {
             var editor: vscode.TextEditor = vscode.window.activeTextEditor as vscode.TextEditor;
 
@@ -21,7 +22,8 @@ export default class PolicBuild {
                 return;
             }
 
-            policyFilter = path.basename(editor.document.fileName);
+            targetPolicy = path.basename(editor.document.fileName);
+            policyFilter = "**/" + targetPolicy;
         }
 
         var rootPath: string;
@@ -170,7 +172,7 @@ export default class PolicBuild {
 
                             if (hasBuiltAnyPolicies) {
                                 if (singlePolicy) {
-                                    vscode.window.showInformationMessage(`Your policy ${policyFilter} successfully exported and stored under the Environment folder.`);
+                                    vscode.window.showInformationMessage(`Your policy ${targetPolicy} successfully exported and stored under the Environment folder.`);
                                 } else {
                                     vscode.window.showInformationMessage("Your policies successfully exported and stored under the Environment folder.");
                                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,7 +90,10 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('ApplicationInsightsExplorer.add', () => InsertCommands.InsertApplicationInsights()));
 
     // Policy build
-    context.subscriptions.push(vscode.commands.registerCommand('extension.policy.build', () => PolicyBuild.Build()));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.policy.build', () => PolicyBuild.Build({singlePolicy: false})));
+    
+    // Policy build
+    context.subscriptions.push(vscode.commands.registerCommand('extension.policy.buildSingle', () => PolicyBuild.Build({singlePolicy: true})));
 
     // Smart copy
     context.subscriptions.push(vscode.commands.registerCommand('extension.policy.smartCopy', () => SmartCopy.Copy()));


### PR DESCRIPTION
This PR adds a command which allows you to build only a single policy. I'm working on a very large project right now and am finding it painful waiting for the full build.
![image](https://user-images.githubusercontent.com/2773983/152461862-2db9536f-4ccc-4261-be12-e757ad219ff4.png)

The build current policy works similarly to the upload current policy, with the exception that it will only ever build an XML file not in the Environments folder (the same as a normal build). If you have open one of built policies in the environments folder, it will properly trigger a build for the "real" policy.

Another feature contributed by this PR is providing a notification in the status bar for build progress. Sometimes the informational completion notification doesn't display unless you click on the notification tray, so this helps solve for that. ![building-policies](https://user-images.githubusercontent.com/2773983/152461677-a98a6acf-14d7-4349-b27f-8283ca3d16ef.gif)